### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -35,6 +35,6 @@ h2. Setup
 
 h2. Misc
 
-* URL for administrative functions is 'http://yourdomain/manage'. Default adminstrator is 'minishopadmin' and password is 'secretpassword'
+* URL for administrative functions is 'http://yourdomain/manage'. Default administrator is 'minishopadmin' and password is 'secretpassword'
 
 * SSL is not enabled


### PR DESCRIPTION
@warrenli, I've corrected a typographical error in the documentation of the [mini-shop](https://github.com/warrenli/mini-shop) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
